### PR TITLE
Switch to fxhash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -159,6 +159,7 @@ name = "csafe"
 version = "0.2.10"
 dependencies = [
  "criterion",
+ "fxhash",
 ]
 
 [[package]]
@@ -188,6 +189,15 @@ name = "either"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
+
+[[package]]
+name = "fxhash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
+dependencies = [
+ "byteorder",
+]
 
 [[package]]
 name = "half"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["sts10 <sschlinkert@gmail.com>"]
 edition = "2018"
 
 [dependencies]
+fxhash = "0.2.1"
 
 [dev-dependencies]
 criterion = "0.3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,8 @@ use std::fs::File;
 use std::io::BufRead;
 use std::io::BufReader;
 
+use fxhash::FxHashSet;
+
 #[derive(Default, Debug, PartialEq)]
 pub struct Contenders {
     pub root_word: String,
@@ -10,7 +12,7 @@ pub struct Contenders {
     pub tail: String,
 }
 
-pub fn find_unsafe_words(list: &HashSet<String>) -> Vec<Contenders> {
+pub fn find_unsafe_words(list: &FxHashSet<String>) -> Vec<Contenders> {
     let mut unsafe_words: Vec<Contenders> = vec![];
     let mut count = 0;
     for root_word in list {
@@ -56,8 +58,8 @@ pub fn find_unsafe_words(list: &HashSet<String>) -> Vec<Contenders> {
     unsafe_words
 }
 
-use std::collections::{HashMap, HashSet};
-pub fn find_fewest_words_to_remove(unsafe_words: Vec<Contenders>) -> HashSet<String> {
+use std::collections::{HashMap};
+pub fn find_fewest_words_to_remove(unsafe_words: Vec<Contenders>) -> FxHashSet<String> {
     // First make a hashmap of appearance counts of all unsafe words
     let mut flat_vec = vec![];
     for contenders in &unsafe_words {
@@ -77,7 +79,7 @@ pub fn find_fewest_words_to_remove(unsafe_words: Vec<Contenders>) -> HashSet<Str
             .or_insert(1);
     }
 
-    let mut words_to_remove = HashSet::new();
+    let mut words_to_remove = FxHashSet::default();
     'outer: for removal_contenders in &unsafe_words {
         let removal_contenders_as_vec = if removal_contenders.tail == "" {
             vec![
@@ -125,17 +127,17 @@ pub fn make_vec_from_file(filename: &str) -> Vec<String> {
     word_list
 }
 
-pub fn make_set_from_file(filename: &str) -> HashSet<String> {
+pub fn make_set_from_file(filename: &str) -> FxHashSet<String> {
     let f = File::open(filename).unwrap();
     let file = BufReader::new(&f);
     file.lines()
-        .collect::<Result<HashSet<_>, _>>()
+        .collect::<Result<FxHashSet<_>, _>>()
         .expect("unable to read word list")
 }
 
 pub fn make_clean_list(
-    words_to_remove: HashSet<String>,
-    original_list: HashSet<String>,
+    words_to_remove: FxHashSet<String>,
+    original_list: FxHashSet<String>,
 ) -> Vec<String> {
     let mut clean_words = original_list
         .difference(&words_to_remove)

--- a/tests/integration-tests.rs
+++ b/tests/integration-tests.rs
@@ -1,6 +1,6 @@
 mod integration_tests {
     use ::csafe::*;
-    use std::collections::HashSet;
+    use fxhash::FxHashSet;
 
     #[test]
     fn can_find_unsafe_words() {
@@ -85,7 +85,7 @@ mod integration_tests {
             ["night", "sea"]
                 .iter()
                 .map(|&s| s.to_owned())
-                .collect::<HashSet<_>>()
+                .collect::<FxHashSet<_>>()
         );
     }
 
@@ -94,11 +94,11 @@ mod integration_tests {
         let list = ["bill", "harry", "ross"]
             .iter()
             .map(|&s| s.to_owned())
-            .collect::<HashSet<_>>();
+            .collect::<FxHashSet<_>>();
         let words_to_remove = ["harry"]
             .iter()
             .map(|&s| s.to_owned())
-            .collect::<HashSet<_>>();
+            .collect::<FxHashSet<_>>();
         assert_eq!(
             make_clean_list(words_to_remove, list),
             vec!["bill".to_string(), "ross".to_string()]


### PR DESCRIPTION
The profile still shows a lot of time spent in `is_on_list`, but now it's time spent calculating hashes. The default hasher in the standard library uses a hash function that is cryptographically secure (sip hash). Since this is not needed for this use case we can use an alternative hasher with better performance. Using fxhash yields about a 30% speed up on the benchmark for me.